### PR TITLE
Change service index

### DIFF
--- a/src/plugins/lightNormals.js
+++ b/src/plugins/lightNormals.js
@@ -175,6 +175,7 @@ class lightNormals extends Component {
 
             this.props.viewer.addHandler('close',  (event) => {
                 this.setState({active: false});
+                this.setState({visible: false});
                 // remove all handlers so viewport-change isn't activated!
                 this.props.viewer.removeAllHandlers('viewport-change');
             });
@@ -205,7 +206,7 @@ class lightNormals extends Component {
     render() {
         const light = this.state.active ? <FlashlightOnIcon/> : <FlashlightOffIcon/>;
 
-        if (typeof this.props.canvas !== 'undefined') {
+        if (typeof this.props.canvas !== 'undefined' && !this.state.visible) {
             this.albedoMap = getMap(this.props.canvas.iiifImageResources, 'albedo');
             this.normalMap = getMap(this.props.canvas.iiifImageResources, 'normal');
 


### PR DESCRIPTION
Made getMap more resilient, by looking for `ImageService` rather than using the index.  Supports v2 and v3 images.  Also anticipates a swap from `http://iiif.io/api/annex/services/lightingmap` to `http://iiif.io/api/extension/lightingmap` planned for iiif in the future.  Added a protection to the render() function to prevent `getMap` being called every render cycle.