### PR TITLE
Fixed: Specify node versions, generate files from v8.15.1 of npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,10 @@
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"
       },
+      "engines": {
+        "node": "^16.17.0",
+        "npm": "^8.15.0"
+      },
       "peerDependencies": {
         "mirador": "^3.0.0-rc.4",
         "react": "16.x",
@@ -2297,9 +2301,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
-      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "version": "17.0.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
+      "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -9037,9 +9041,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
-      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "version": "17.0.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
+      "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,9 @@
     "webpack": "^5.5.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"
+  },
+  "engines": {
+    "node": "^16.17.0",
+    "npm": "^8.15.0"
   }
 }


### PR DESCRIPTION
C/I in https://gitlab.bodleian.ox.ac.uk/digital.bodleian/2.0/mirador_plugins_build uses npm version 8.15.1, I was using 8.5, this is causing conflicts between lock files.