### PR TITLE
Fixed: v5 MUI not available

### DIFF
--- a/src/plugins/lightNormals.js
+++ b/src/plugins/lightNormals.js
@@ -143,7 +143,7 @@ function MenuButton(props) {
             }}
             onClick={ props.onClick }
         >
-            { props.open ? <CloseSharpIcon /> : <GamepadIcon/> }
+            { props.open ? <CloseSharpIcon /> : <GamepadIcon /> }
         </button>
     );
 }


### PR DESCRIPTION
Use `GamepadIcon` as an alternative to the `ViewInAr` icon because it is not available in v4 of MUI.

We can always find a better icon at a later date if need be.