### PR TITLE
Change light z distance

### DIFF
--- a/src/plugins/threeCanvas.js
+++ b/src/plugins/threeCanvas.js
@@ -178,7 +178,7 @@ class ThreeCanvas extends React.Component{
         let dir = vector.sub(this.camera.position).normalize();
         let distance = -this.camera.position.z / dir.z;
         let pos = this.camera.position.clone().add(dir.multiplyScalar(distance));
-        this.directionalLight.position.set(pos.x, pos.y, 0.5);
+        this.directionalLight.position.set(pos.x, pos.y, pos.z + 2);
     }
 
     componentDidMount() {


### PR DESCRIPTION
The z position calculation for the light was wrong, it was overly sensitive and made the image go darker than it should under raking light.  This has now been fixed by mapping the transformation to the z coordinate as well as the x, y coordinates for the directional light position.