### PR TITLE
Fix touch event mobile

### DIFF
--- a/src/plugins/lightNormals.js
+++ b/src/plugins/lightNormals.js
@@ -328,11 +328,8 @@ class lightNormals extends Component {
     }
 
     onMouseMove(event) {
-
         const control = document.getElementById("LightDirectionControl");
         const boundingBox = control.getBoundingClientRect();
-
-        console.log(typeof event.type);
 
         if (event.type==="mousemove") {
             event.preventDefault();


### PR DESCRIPTION
* Adds `onTouchMove` event to the `LightDirection` component which makes use of the `onMouseMove` function.  This should allow devices without a mouse to move the light direction with their finger.