### PR TITLE
Fixed: Always turn on required layers

### DIFF
--- a/src/plugins/Relight.js
+++ b/src/plugins/Relight.js
@@ -189,6 +189,11 @@ class Relight extends React.Component {
     // only turn the composite image back on
     this.setState((prevState) => ({ active: !prevState.active }));
 
+    // always turn on albedo and normal regardless
+    this.excluded_maps = ['albedo', 'normal'];
+    this.updateLayer(this.excluded_maps, this.canvasID, this.layers, true);
+
+    // toggle on or off composite
     this.excluded_maps = ['composite'];
     this.updateLayer(
       this.excluded_maps,


### PR DESCRIPTION
This fix turns on required layers on toggle on or off which should mitigate people switching the layers off before relighting.


Closes: #65