### PR TITLE
Fix: Rotation style conflict regression

### DIFF
--- a/src/plugins/Relight.js
+++ b/src/plugins/Relight.js
@@ -68,7 +68,6 @@ class Relight extends React.Component {
     this.helperOn = false;
     this.renderMode = true;
     this.albedoInfo = {};
-    this.style = '';
 
     if (!this.renderMode) {
       this.normalDepth = 10.0;
@@ -84,8 +83,8 @@ class Relight extends React.Component {
    * this also updates the props passed to the Three canvas.
    * */
   onMouseMove(event, id, rotation) {
-    const control = document.getElementById(id);
-    const boundingBox = control.getBoundingClientRect();
+    const lightDirectionControl = document.getElementById(id);
+    const boundingBox = lightDirectionControl.getBoundingClientRect();
 
     let xMove;
     let yMove;
@@ -100,11 +99,11 @@ class Relight extends React.Component {
       yMove = event.touches[0].clientY - boundingBox.top;
     }
 
-    // rotation is the total degrees the canvas has rotated, i.e. it stacks, we need to get this back
-    // to a relative number by using modulus...
-    const rotationModulus = rotation % 360;
-
     if (this.mouseDown) {
+      // rotation is the total degrees the canvas has rotated, i.e. it stacks, we need to get this back
+      // to a relative number by using modulus...
+      const rotationModulus = rotation % 360;
+
       switch (rotationModulus) {
         case 0:
           this.mouseX = xMove;
@@ -112,12 +111,6 @@ class Relight extends React.Component {
           this.lightX = (this.mouseX / 100) * 2 - 1;
           this.lightY = (this.mouseY / 100) * 2 - 1;
           this.lightX = this.flipped ? -this.lightX : this.lightX;
-          this.style =
-            `radial-gradient(at ` +
-            this.mouseX +
-            `% ` +
-            this.mouseY +
-            `%, #ffffff, #000000)`;
           break;
         case -270:
         case 90:
@@ -126,12 +119,6 @@ class Relight extends React.Component {
           this.lightX = (this.mouseX / 100) * 2 - 1;
           this.lightY = -((this.mouseY / 100) * 2 - 1);
           this.lightY = this.flipped ? -this.lightY : this.lightY;
-          this.style =
-            `radial-gradient(at ` +
-            this.mouseY +
-            `% ` +
-            this.mouseX +
-            `%, #ffffff, #000000)`;
           break;
         case -180:
         case 180:
@@ -140,12 +127,6 @@ class Relight extends React.Component {
           this.lightX = -((this.mouseX / 100) * 2 - 1);
           this.lightY = -((this.mouseY / 100) * 2 - 1);
           this.lightX = this.flipped ? -this.lightX : this.lightX;
-          this.style =
-            `radial-gradient(at ` +
-            this.mouseX +
-            `% ` +
-            this.mouseY +
-            `%, #ffffff, #000000)`;
           break;
         case -90:
         case 270:
@@ -154,14 +135,7 @@ class Relight extends React.Component {
           this.lightX = -((this.mouseX / 100) * 2 - 1);
           this.lightY = (this.mouseY / 100) * 2 - 1;
           this.lightY = this.flipped ? -this.lightY : this.lightY;
-          this.style =
-            `radial-gradient(at ` +
-            this.mouseY +
-            `% ` +
-            this.mouseX +
-            `%, #ffffff, #000000)`;
       }
-      control.style.background = this.style;
       this.threeCanvasProps.lightX = this.lightX;
       this.threeCanvasProps.lightY = this.lightY;
 
@@ -871,6 +845,7 @@ class Relight extends React.Component {
                   this.rotation
                 )
               }
+              rotation={this.rotation}
             />
           </div>
           {toolMenuSliders}

--- a/src/plugins/RelightLightDirection.js
+++ b/src/plugins/RelightLightDirection.js
@@ -12,6 +12,49 @@ import PropTypes from 'prop-types';
 class RelightLightDirection extends React.Component {
   constructor(props) {
     super(props);
+    // todo: figure out rotation and style here, so there's no conflicts...
+  }
+  calculateBackgroundStyle(rotation, mouseX, mouseY) {
+    const rotationModulus = rotation % 360;
+    let style;
+
+    switch (rotationModulus) {
+      case 0:
+        style =
+          `radial-gradient(at ` +
+          mouseX +
+          `% ` +
+          mouseY +
+          `%, #ffffff, #000000)`;
+        break;
+      case -270:
+      case 90:
+        style =
+          `radial-gradient(at ` +
+          mouseY +
+          `% ` +
+          mouseX +
+          `%, #ffffff, #000000)`;
+        break;
+      case -180:
+      case 180:
+        style =
+          `radial-gradient(at ` +
+          mouseX +
+          `% ` +
+          mouseY +
+          `%, #ffffff, #000000)`;
+        break;
+      case -90:
+      case 270:
+        style =
+          `radial-gradient(at ` +
+          mouseY +
+          `% ` +
+          mouseX +
+          `%, #ffffff, #000000)`;
+    }
+    return style;
   }
   render() {
     const {
@@ -23,6 +66,7 @@ class RelightLightDirection extends React.Component {
       onMouseDown,
       onMouseUp,
       onMouseLeave,
+      rotation,
     } = this.props;
     return (
       <>
@@ -35,12 +79,11 @@ class RelightLightDirection extends React.Component {
               height: '100px',
               margin: '13px',
               borderRadius: '50px',
-              background:
-                `radial-gradient(at ` +
-                mouseX +
-                `% ` +
-                mouseY +
-                `%, #ffffff, #000000)`,
+              background: this.calculateBackgroundStyle(
+                rotation,
+                mouseX,
+                mouseY
+              ),
             }}
             aria-label="Change light direction"
             aria-expanded="False"
@@ -75,6 +118,12 @@ RelightLightDirection.propTypes = {
   mouseX: PropTypes.number,
   /** The mouseY prop is the current y coordinate of the mouse or touch event **/
   mouseY: PropTypes.number,
+  /** The rotation prop is the current rotation of the viewer**/
+  rotation: PropTypes.number,
 };
 
+RelightLightDirection.defaultProps = {
+  mouseX: 50,
+  mouseY: 50,
+};
 export default RelightLightDirection;


### PR DESCRIPTION
Attempting to fix light direction sphere style caused a rendering conflict.  The fix was to move all style control to the child component so it's only doing it in one place.

Closes: #129 