### PR TITLE
97 unhandled null intersection

### DIFF
--- a/src/plugins/RelightHelpers.js
+++ b/src/plugins/RelightHelpers.js
@@ -260,6 +260,8 @@ export function getRendererInstructions(props) {
     rendererInstructions.intersection = intersection;
     return rendererInstructions;
   }
+  rendererInstructions.intersection = { "x": 0, "y": 0, "width": 0, "height": 0, "degress": 0 }
+  return rendererInstructions;
 }
 
 /**


### PR DESCRIPTION
If intersection is undefined then define an empty one to prevent the threejs canvas crashing

Closes: #97 