### PR TITLE
150 do not reset normals

### DIFF
--- a/src/plugins/Relight.js
+++ b/src/plugins/Relight.js
@@ -490,7 +490,6 @@ class Relight extends React.Component {
    **/
   renderHandler() {
     this.renderMode = !this.renderMode;
-    this.resetHandler(this.props.relightLightDirectionID);
     this.updateOverlay();
   }
 

--- a/src/plugins/RelightHelpers.js
+++ b/src/plugins/RelightHelpers.js
@@ -260,7 +260,13 @@ export function getRendererInstructions(props) {
     rendererInstructions.intersection = intersection;
     return rendererInstructions;
   }
-  rendererInstructions.intersection = { "x": 0, "y": 0, "width": 0, "height": 0, "degress": 0 }
+  rendererInstructions.intersection = {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    degress: 0,
+  };
   return rendererInstructions;
 }
 


### PR DESCRIPTION
When the user toggles the shader mode the light settings are now preserved, this protects from accidentally pressing it and losing your settings.

Closes: #150 